### PR TITLE
fix(go.lua): change buf to bufnr as buf is a global var making error …

### DIFF
--- a/lua/plugins/extras/lang/go.lua
+++ b/lua/plugins/extras/lang/go.lua
@@ -240,14 +240,14 @@ return {
 
               vim.api.nvim_create_autocmd("InsertEnter", {
                 group = inlay_hints_group,
-                buffer = buf,
+                buffer = bufnr,
                 callback = function()
                   vim.lsp.inlay_hint.enable(bufnr, false)
                 end,
               })
               vim.api.nvim_create_autocmd("InsertLeave", {
                 group = inlay_hints_group,
-                buffer = buf,
+                buffer = bufnr,
                 callback = function()
                   vim.lsp.inlay_hint.enable(bufnr, true)
                 end,


### PR DESCRIPTION
…when doing autocmd as the value must be gopls buffer only